### PR TITLE
Add concept: "Mergable" to Pull Request

### DIFF
--- a/server/events/vcs/bitbucketcloud/client.go
+++ b/server/events/vcs/bitbucketcloud/client.go
@@ -119,6 +119,34 @@ func (b *Client) PullIsApproved(repo models.Repo, pull models.PullRequest) (bool
 	return false, nil
 }
 
+// PullIsMergeable returns true if the merge request was approved.
+func (b *Client) PullIsMergeable(repo models.Repo, pull models.PullRequest) (bool, error) {
+
+	// TODO: (MattAndMike) implement
+	return false, nil
+
+	// path := fmt.Sprintf("%s/2.0/repositories/%s/pullrequests/%d", b.BaseURL, repo.FullName, pull.Num)
+	// resp, err := b.makeRequest("GET", path, nil)
+	// if err != nil {
+	// 	return false, err
+	// }
+	// var pullResp PullRequest
+	// if err := json.Unmarshal(resp, &pullResp); err != nil {
+	// 	return false, errors.Wrapf(err, "Could not parse response %q", string(resp))
+	// }
+	// if err := validator.New().Struct(pullResp); err != nil {
+	// 	return false, errors.Wrapf(err, "API response %q was missing fields", string(resp))
+	// }
+	// for _, participant := range pullResp.Participants {
+	// 	// Bitbucket allows the author to approve their own pull request. This
+	// 	// defeats the purpose of approvals so we don't count that approval.
+	// 	if *participant.Approved && *participant.User.Username != pull.Author {
+	// 		return true, nil
+	// 	}
+	// }
+	// return false, nil
+}
+
 // UpdateStatus updates the status of a commit.
 func (b *Client) UpdateStatus(repo models.Repo, pull models.PullRequest, status models.CommitStatus, description string) error {
 	bbState := "FAILED"

--- a/server/events/vcs/bitbucketserver/client.go
+++ b/server/events/vcs/bitbucketserver/client.go
@@ -158,6 +158,36 @@ func (b *Client) PullIsApproved(repo models.Repo, pull models.PullRequest) (bool
 	return false, nil
 }
 
+// PullIsMergeable returns true if the merge request was approved.
+func (b *Client) PullIsMergeable(repo models.Repo, pull models.PullRequest) (bool, error) {
+
+	// TODO: (MattAndMike) implement
+	return false, nil
+
+	// projectKey, err := b.GetProjectKey(repo.Name, repo.SanitizedCloneURL)
+	// if err != nil {
+	// 	return false, err
+	// }
+	// path := fmt.Sprintf("%s/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d", b.BaseURL, projectKey, repo.Name, pull.Num)
+	// resp, err := b.makeRequest("GET", path, nil)
+	// if err != nil {
+	// 	return false, err
+	// }
+	// var pullResp PullRequest
+	// if err := json.Unmarshal(resp, &pullResp); err != nil {
+	// 	return false, errors.Wrapf(err, "Could not parse response %q", string(resp))
+	// }
+	// if err := validator.New().Struct(pullResp); err != nil {
+	// 	return false, errors.Wrapf(err, "API response %q was missing fields", string(resp))
+	// }
+	// for _, reviewer := range pullResp.Reviewers {
+	// 	if *reviewer.Approved {
+	// 		return true, nil
+	// 	}
+	// }
+	// return false, nil
+}
+
 // UpdateStatus updates the status of a commit.
 func (b *Client) UpdateStatus(repo models.Repo, pull models.PullRequest, status models.CommitStatus, description string) error {
 	bbState := "FAILED"

--- a/server/events/vcs/client.go
+++ b/server/events/vcs/client.go
@@ -24,5 +24,6 @@ type Client interface {
 	GetModifiedFiles(repo models.Repo, pull models.PullRequest) ([]string, error)
 	CreateComment(repo models.Repo, pullNum int, comment string) error
 	PullIsApproved(repo models.Repo, pull models.PullRequest) (bool, error)
+	PullIsMergeable(repo models.Repo, pull models.PullRequest) (bool, error)
 	UpdateStatus(repo models.Repo, pull models.PullRequest, state models.CommitStatus, description string) error
 }

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -115,6 +115,23 @@ func (g *GithubClient) PullIsApproved(repo models.Repo, pull models.PullRequest)
 	return false, nil
 }
 
+// PullIsMergeable returns true if the pull request was approved.
+func (g *GithubClient) PullIsMergeable(repo models.Repo, pull models.PullRequest) (bool, error) {
+
+	// TODO: (MattAndMike) add impl that looks for mergable flag
+	return false, nil
+	// reviews, _, err := g.client.PullRequests.ListReviews(g.ctx, repo.Owner, repo.Name, pull.Num, nil)
+	// if err != nil {
+	// 	return false, errors.Wrap(err, "getting reviews")
+	// }
+	// for _, review := range reviews {
+	// 	if review != nil && review.GetState() == "APPROVED" {
+	// 		return true, nil
+	// 	}
+	// }
+	// return false, nil
+}
+
 // GetPullRequest returns the pull request.
 func (g *GithubClient) GetPullRequest(repo models.Repo, num int) (*github.PullRequest, error) {
 	pull, _, err := g.client.PullRequests.Get(g.ctx, repo.Owner, repo.Name, num)

--- a/server/events/vcs/gitlab_client.go
+++ b/server/events/vcs/gitlab_client.go
@@ -78,6 +78,22 @@ func (g *GitlabClient) PullIsApproved(repo models.Repo, pull models.PullRequest)
 	return true, nil
 }
 
+// PullIsMergeable returns true if the merge request was approved.
+func (g *GitlabClient) PullIsMergeable(repo models.Repo, pull models.PullRequest) (bool, error) {
+
+	// TODO: (MattAndMike) - add actual impl
+	return false, nil
+
+	// approvals, _, err := g.Client.MergeRequests.GetMergeRequestApprovals(repo.FullName, pull.Num)
+	// if err != nil {
+	// 	return false, err
+	// }
+	// if approvals.ApprovalsLeft > 0 {
+	// 	return false, nil
+	// }
+	// return true, nil
+}
+
 // UpdateStatus updates the build status of a commit.
 func (g *GitlabClient) UpdateStatus(repo models.Repo, pull models.PullRequest, state models.CommitStatus, description string) error {
 	const statusContext = "Atlantis"

--- a/server/events/vcs/mocks/mock_proxy.go
+++ b/server/events/vcs/mocks/mock_proxy.go
@@ -62,6 +62,22 @@ func (mock *MockClientProxy) PullIsApproved(repo models.Repo, pull models.PullRe
 	return ret0, ret1
 }
 
+func (mock *MockClientProxy) PullIsMergeable(repo models.Repo, pull models.PullRequest) (bool, error) {
+	params := []pegomock.Param{repo, pull}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("PullIsMergeable", params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 bool
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(bool)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
+
 func (mock *MockClientProxy) UpdateStatus(repo models.Repo, pull models.PullRequest, state models.CommitStatus, description string) error {
 	params := []pegomock.Param{repo, pull, state, description}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("UpdateStatus", params, []reflect.Type{reflect.TypeOf((*error)(nil)).Elem()})

--- a/server/events/vcs/not_configured_vcs_client.go
+++ b/server/events/vcs/not_configured_vcs_client.go
@@ -35,6 +35,9 @@ func (a *NotConfiguredVCSClient) CreateComment(repo models.Repo, pullNum int, co
 func (a *NotConfiguredVCSClient) PullIsApproved(repo models.Repo, pull models.PullRequest) (bool, error) {
 	return false, a.err()
 }
+func (a *NotConfiguredVCSClient) PullIsMergeable(repo models.Repo, pull models.PullRequest) (bool, error) {
+	return false, a.err()
+}
 func (a *NotConfiguredVCSClient) UpdateStatus(repo models.Repo, pull models.PullRequest, state models.CommitStatus, description string) error {
 	return a.err()
 }

--- a/server/events/vcs/proxy.go
+++ b/server/events/vcs/proxy.go
@@ -25,6 +25,7 @@ type ClientProxy interface {
 	GetModifiedFiles(repo models.Repo, pull models.PullRequest) ([]string, error)
 	CreateComment(repo models.Repo, pullNum int, comment string) error
 	PullIsApproved(repo models.Repo, pull models.PullRequest) (bool, error)
+	PullIsMergeable(repo models.Repo, pull models.PullRequest) (bool, error)
 	UpdateStatus(repo models.Repo, pull models.PullRequest, state models.CommitStatus, description string) error
 }
 
@@ -69,6 +70,10 @@ func (d *DefaultClientProxy) CreateComment(repo models.Repo, pullNum int, commen
 
 func (d *DefaultClientProxy) PullIsApproved(repo models.Repo, pull models.PullRequest) (bool, error) {
 	return d.clients[repo.VCSHost.Type].PullIsApproved(repo, pull)
+}
+
+func (d *DefaultClientProxy) PullIsMergeable(repo models.Repo, pull models.PullRequest) (bool, error) {
+	return d.clients[repo.VCSHost.Type].PullIsMergeable(repo, pull)
 }
 
 func (d *DefaultClientProxy) UpdateStatus(repo models.Repo, pull models.PullRequest, state models.CommitStatus, description string) error {


### PR DESCRIPTION
WIP (Work In Progress) - DO NOT MERGE

When Atlantis inspects a Pull Request to determine if it can
run "terraform apply" it (presently) only looks to see if any
of the reviewers have approved the PR.  This commit adds
the concept of "Mergeable" - affording projects the ability
to attract new contributors (by allowing them to approve
PR's) without allowing those PR's to be merged without
approval from the project owners.  The github v3 API
models "Mergeable" [1] for this purpose.

[1] https://godoc.org/github.com/google/go-github/github#PullRequest.GetMergeable

---

Remaining workitems:

- actually implement PullIsMergable()
- ensure coverage from e2e tests
- test with actual PR's from our terraform repo